### PR TITLE
fix @ajnavarro comments to https://github.com/bblfsh/bash-driver/pull/3

### DIFF
--- a/native/build.gradle
+++ b/native/build.gradle
@@ -12,6 +12,6 @@ repositories {
 
 dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.12'
-    compile 'com.github.jansorg:BashSupport:idea-171.x-SNAPSHOT'
+    compile 'com.github.jansorg:BashSupport:1c92743a01'
     compile fileTree(dir: 'vendor/idea-IC-171.3780.107/lib', include: ['*.jar'])
 }

--- a/native/src/main/java/bblfsh/bash/Parser.java
+++ b/native/src/main/java/bblfsh/bash/Parser.java
@@ -3,6 +3,7 @@ package bblfsh.bash;
 import com.ansorgit.plugins.bash.lang.BashVersion;
 import com.ansorgit.plugins.bash.lang.lexer.BashElementType;
 import com.ansorgit.plugins.bash.lang.lexer.BashLexer;
+import com.ansorgit.plugins.bash.lang.parser.BashParser;
 import com.ansorgit.plugins.bash.lang.parser.BashParserDefinition;
 import com.ansorgit.plugins.bash.lang.parser.BashPsiBuilder;
 import com.ansorgit.plugins.bash.lang.parser.FileParsing;
@@ -19,11 +20,10 @@ import com.intellij.openapi.extensions.ExtensionsArea;
 import com.intellij.openapi.extensions.Extensions;
 import com.intellij.lang.MetaLanguage;
 
-public class BashParser {
+public class Parser {
     public static ASTNode run(final CharSequence code, final BashVersion version) {
         final MockProject project = project();
-        final com.ansorgit.plugins.bash.lang.parser.BashParser parser =
-                new com.ansorgit.plugins.bash.lang.parser.BashParser(project, version);
+        final BashParser parser = new BashParser(project, version);
         final ParserDefinition parserDefinition = new BashParserDefinition();
 
         final PsiBuilder builder = builder(parserDefinition, code);

--- a/native/src/test/java/bblfsh/bash/ViabilityTest.java
+++ b/native/src/test/java/bblfsh/bash/ViabilityTest.java
@@ -10,7 +10,7 @@ public class ViabilityTest {
     public void canParse() {
         final String code = "#!/bin/bash\na=3; echo ${a}";
         final BashVersion version = BashVersion.Bash_v4;
-        final ASTNode root = BashParser.run(code, version);
+        final ASTNode root = Parser.run(code, version);
         assertNotNull(root);
     }
 }


### PR DESCRIPTION
1. https://github.com/bblfsh/bash-driver/pull/3/files/b5e289bdc1787c8221456353285a6a0671cb74c4#r110868583 : version changed from SNAPSHOT to 1c92743a01 which is the last known commit of that same version.
2. https://github.com/bblfsh/bash-driver/pull/3/files/b5e289bdc1787c8221456353285a6a0671cb74c4#r110868891 : BashParser refactored to Parser so there is no longer a name collision between both classes.
