### PR TITLE
Full sdk integration

### DIFF
--- a/Dockerfile.tpl
+++ b/Dockerfile.tpl
@@ -1,3 +1,9 @@
 FROM alpine:3.5
 
+ARG RUNTIME_NATIVE_VERSION
+ENV RUNTIME_NATIVE_VERSION $RUNTIME_NATIVE_VERSION
+
+RUN apk add --no-cache openjdk8-jre="$RUNTIME_NATIVE_VERSION"
+
+ADD build /opt/driver/bin
 CMD /opt/driver/bin/driver

--- a/Makefile
+++ b/Makefile
@@ -2,14 +2,20 @@
 
 $(if $(filter true,$(sdkloaded)),,$(error You must install bblfsh-sdk))
 
+NATIVE_SCRIPT := native/src/main/ash/native.ash
+DOWNLOAD_VENDOR = make
+BUILD = gradle
+JAR := native/build/libs/native-jar-with-dependencies.jar
+
 test-native-internal:
 	cd native; \
-		make; \
-		gradle test
+		$(DOWNLOAD_VENDOR); \
+		$(BUILD) test
 
 build-native-internal:
 	cd native; \
-		make; \
-		gradle installDist;
-	echo '#!/usr/bin/env bash\nDIR="$$( cd "$$( dirname "$${BASH_SOURCE[0]}" )" && pwd )"\ncd $${DIR}/../native\nbuild/install/bashdriver/bin/bashdriver' > build/native
-	chmod u+x build/native
+		$(DOWNLOAD_VENDOR); \
+		$(BUILD) shadowJar;
+	cp $(JAR) $(BUILD_PATH);
+	cp $(NATIVE_SCRIPT) $(BUILD_PATH)/native;
+	chmod +x $(BUILD_PATH)/native

--- a/native/build.gradle
+++ b/native/build.gradle
@@ -1,10 +1,10 @@
+plugins {
+    id 'com.github.johnrengelman.shadow' version "1.2.4"
+}
+apply plugin: 'java'
+
 group 'bblfsh'
 version '1.0-SNAPSHOT'
-
-apply plugin: 'java'
-apply plugin: 'application'
-
-mainClassName = 'bblfsh.bash.Main'
 
 sourceCompatibility = 1.8
 
@@ -25,5 +25,16 @@ dependencies {
 test {
     testLogging {
         events "passed", "skipped", "failed", "standardOut", "standardError"
+    }
+}
+
+shadowJar {
+    baseName='bashdriver'
+    archiveName='native-jar-with-dependencies.jar'
+}
+
+jar {
+    manifest {
+        attributes 'Main-Class': 'bblfsh.bash.Main'
     }
 }

--- a/native/src/main/ash/native.ash
+++ b/native/src/main/ash/native.ash
@@ -1,0 +1,5 @@
+#!/usr/bin/env ash
+JAR=native-jar-with-dependencies.jar
+BIN="`readlink -f $0`"
+DIR="`dirname "$BIN"`"
+exec java -jar "$DIR/$JAR"


### PR DESCRIPTION
Now a full demo can be done by passing a bash script to the driver running in a docker, as in the bblfsh documentation.

Merge https://github.com/bblfsh/bash-driver/pull/9 first.