### PR TITLE
Support error codes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ services:
   - docker
 
 env:
-  - BBLFSHD_VERSION=v2.6.1
+  - BBLFSHD_VERSION=v2.9.1
 
-before_script:
+install:
   - curl -L https://github.com/golang/dep/releases/download/v0.4.1/dep-linux-amd64 > $GOPATH/bin/dep
   - chmod +x $GOPATH/bin/dep
   - dep ensure --vendor-only

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -287,6 +287,7 @@
   name = "gopkg.in/bblfsh/sdk.v2"
   packages = [
     "driver",
+    "driver/errors",
     "driver/fixtures",
     "driver/manifest",
     "driver/native",
@@ -305,8 +306,8 @@
     "uast/viewer",
     "uast/yaml"
   ]
-  revision = "966e28c602fb968fc52e27e14762bdf9307da229"
-  version = "v2.1.0"
+  revision = "422edc29a23d6d79d6f8fbe0a6f9dffcc3ff9ab2"
+  version = "v2.4.1"
 
 [[projects]]
   name = "gopkg.in/src-d/go-errors.v1"
@@ -323,6 +324,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "400b85f6c421dfd45444be2e9b24fdb5b854dccae85a63295585aa3070197789"
+  inputs-digest = "1391b700535f06ff4bec504f0925e757081b97114f1420d07da20e6ee08db857"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -306,8 +306,8 @@
     "uast/viewer",
     "uast/yaml"
   ]
-  revision = "422edc29a23d6d79d6f8fbe0a6f9dffcc3ff9ab2"
-  version = "v2.4.1"
+  revision = "25b3f8adb4ba7ff703973b3aefb0f6b8a90dae30"
+  version = "v2.5.0"
 
 [[projects]]
   name = "gopkg.in/src-d/go-errors.v1"
@@ -324,6 +324,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "1391b700535f06ff4bec504f0925e757081b97114f1420d07da20e6ee08db857"
+  inputs-digest = "1c8fe61e271ffb1f2ac48cadbc6fc5dc5d89b481ca4f60bfa244b392c8f3b1e6"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -3,7 +3,7 @@
 
 [[constraint]]
   name = "gopkg.in/bblfsh/sdk.v2"
-  version = "v2.1.x"
+  version = "v2.4.x"
 
 [prune]
   go-tests = true

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -3,7 +3,7 @@
 
 [[constraint]]
   name = "gopkg.in/bblfsh/sdk.v2"
-  version = "v2.4.x"
+  version = "v2.5.x"
 
 [prune]
   go-tests = true

--- a/fixtures/_syntax_error.bash
+++ b/fixtures/_syntax_error.bash
@@ -1,0 +1,6 @@
+testfnc1() { 
+    : 
+}
+function = testfnc2 = {
+    : 
+}


### PR DESCRIPTION
Support error codes and add a syntax error check.

But the test will fail since the driver doesn't emit any syntax errors currently, regardless of what is written in the source file. It needs to be solved before merging it.