### PR TITLE
Add actual go version to manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Bash driver for [Babelfish](https://github.com/bblfsh/bblfshd) ![Driver Status](https://img.shields.io/badge/status-beta-dbd25c.svg) [![Build Status](https://travis-ci.org/bblfsh/bash-driver.svg?branch=master)](https://travis-ci.org/bblfsh/bash-driver) ![Native Version](https://img.shields.io/badge/bash%20version-8.131.11--r2-aa93ea.svg) ![Go Version](https://img.shields.io/badge/go%20version-1.9-63afbf.svg)
+# Bash driver for [Babelfish](https://github.com/bblfsh/bblfshd) ![Driver Status](https://img.shields.io/badge/status-beta-dbd25c.svg) [![Build Status](https://travis-ci.org/bblfsh/bash-driver.svg?branch=master)](https://travis-ci.org/bblfsh/bash-driver) ![Native Version](https://img.shields.io/badge/bash%20version-8.131.11--r2-aa93ea.svg) ![Go Version](https://img.shields.io/badge/go%20version-1.11-63afbf.svg)
 
 bash driver for [babelfish](https://github.com/bblfsh/bblfshd).
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -10,5 +10,5 @@ bash driver for [babelfish](https://github.com/bblfsh/bblfshd).
 
 [runtime]
 os = "alpine"
-go_version = "1.9"
+go_version = "1.11"
 native_version = ["8.131.11-r2"]


### PR DESCRIPTION
Otherwise, this results in confusing information in readme: header and text below mention different Go versions now.

<img width="845" alt="Screen Shot 2019-03-26 at 4 31 19 PM" src="https://user-images.githubusercontent.com/5582506/55010526-9d32ca00-4fe4-11e9-94bc-f7d991d1b32a.png">
