### PR TITLE
Pin OpenJDK image version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 #==============================
 # Stage 1: Native Driver Build
 #==============================
-FROM openjdk:8-slim as native
+FROM openjdk:8u181-slim as native
 
 # install build dependencies
 RUN apt-get update && apt-get install -y make bash wget gradle
@@ -62,7 +62,7 @@ RUN go test -c -o /tmp/fixtures.test ./driver/fixtures/
 #=======================
 # Stage 3: Driver Build
 #=======================
-FROM openjdk:8-jre-alpine
+FROM openjdk:8u181-jre-alpine
 
 
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Bash driver for [Babelfish](https://github.com/bblfsh/bblfshd) ![Driver Status](https://img.shields.io/badge/status-beta-dbd25c.svg) [![Build Status](https://travis-ci.org/bblfsh/bash-driver.svg?branch=master)](https://travis-ci.org/bblfsh/bash-driver) ![Native Version](https://img.shields.io/badge/bash%20version-8-aa93ea.svg) ![Go Version](https://img.shields.io/badge/go%20version-1.12-63afbf.svg)
+# Bash driver for [Babelfish](https://github.com/bblfsh/bblfshd) ![Driver Status](https://img.shields.io/badge/status-beta-dbd25c.svg) [![Build Status](https://travis-ci.org/bblfsh/bash-driver.svg?branch=master)](https://travis-ci.org/bblfsh/bash-driver) ![Native Version](https://img.shields.io/badge/bash%20version-8u181-aa93ea.svg) ![Go Version](https://img.shields.io/badge/go%20version-1.12-63afbf.svg)
 
 bash driver for [babelfish](https://github.com/bblfsh/bblfshd).
 

--- a/build.yml
+++ b/build.yml
@@ -3,12 +3,12 @@ language: bash
 go-runtime:
   version: '1.12-alpine'
 native:
-  image: 'openjdk:8-jre-alpine'
+  image: 'openjdk:8u181-jre-alpine'
   static:
       - path: native.sh
         dest: native
   build:
-    image: 'openjdk:8-slim'
+    image: 'openjdk:8u181-slim'
     deps:
       - 'apt-get update && apt-get install -y make bash wget gradle'
     run:


### PR DESCRIPTION
Pin OpenJDK image version to prevent CI failures.

Signed-off-by: Denys Smirnov <denys@sourced.tech>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bblfsh/bash-driver/61)
<!-- Reviewable:end -->
