### PR TITLE
Bump Go version to 1.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN gradle test --info --stacktrace
 #=================================
 # Stage 2: Go Driver Server Build
 #=================================
-FROM golang:1.12-alpine as driver
+FROM golang:1.13-alpine as driver
 
 ENV DRIVER_REPO=github.com/bblfsh/bash-driver
 ENV DRIVER_REPO_PATH=/go/src/$DRIVER_REPO

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Bash driver for [Babelfish](https://github.com/bblfsh/bblfshd) ![Driver Status](https://img.shields.io/badge/status-beta-dbd25c.svg) [![Build Status](https://travis-ci.org/bblfsh/bash-driver.svg?branch=master)](https://travis-ci.org/bblfsh/bash-driver) ![Native Version](https://img.shields.io/badge/bash%20version-8u181-aa93ea.svg) ![Go Version](https://img.shields.io/badge/go%20version-1.12-63afbf.svg)
+# Bash driver for [Babelfish](https://github.com/bblfsh/bblfshd) ![Driver Status](https://img.shields.io/badge/status-beta-dbd25c.svg) [![Build Status](https://travis-ci.org/bblfsh/bash-driver.svg?branch=master)](https://travis-ci.org/bblfsh/bash-driver) ![Native Version](https://img.shields.io/badge/bash%20version-8u181-aa93ea.svg) ![Go Version](https://img.shields.io/badge/go%20version-1.13-63afbf.svg)
 
 bash driver for [babelfish](https://github.com/bblfsh/bblfshd).
 
@@ -8,7 +8,7 @@ Development Environment
 
 Requirements:
 - `docker`
-- Go 1.12+
+- Go 1.13+
 
 To initialize the build system execute: `go test ./driver`, at the root of the project. This will generate the `Dockerfile` for this driver.
 

--- a/build.yml
+++ b/build.yml
@@ -1,7 +1,7 @@
 sdk: '2'
 language: bash
 go-runtime:
-  version: '1.12-alpine'
+  version: '1.13-alpine'
 native:
   image: 'openjdk:8u181-jre-alpine'
   static:


### PR DESCRIPTION
Bump Go version to 1.13.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bblfsh/bash-driver/72)
<!-- Reviewable:end -->
